### PR TITLE
Made GetPocoMapper method public

### DIFF
--- a/src/SqlFu/PocoFactory.cs
+++ b/src/SqlFu/PocoFactory.cs
@@ -103,7 +103,7 @@ namespace SqlFu
         }
 
 
-        internal static Func<IDataReader, T> GetPocoMapper<T>(IDataReader rd, string sql)
+        public static Func<IDataReader, T> GetPocoMapper<T>(IDataReader rd, string sql)
         {
             var poco = typeof (T);
 


### PR DESCRIPTION
This would give greater flexibility in extending the Fetch method. In my example, I'm pulling total row counts on paged queries within stored procedures that can't be outputted via traditional SP output parameters. This little bit of flexibility means I can re-use the super fast poco mapper already in SqlFu but still have the access to the data reader to grab additional information that I need. It would also mean I can create a custom generic query across all my objects by reusing all the work SqlFu already does.

It would be really powerful, and all that is need is access to is the GetPocoMapper method.